### PR TITLE
Add ImmutableGraphUtil

### DIFF
--- a/core/src/main/kotlin/org/octogonapus/ktguava/collections/ImmutableGraphUtil.kt
+++ b/core/src/main/kotlin/org/octogonapus/ktguava/collections/ImmutableGraphUtil.kt
@@ -1,0 +1,61 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.octogonapus.ktguava.collections
+
+import com.google.common.graph.Graph
+import com.google.common.graph.GraphBuilder
+import com.google.common.graph.ImmutableGraph
+import com.google.common.graph.MutableGraph
+import com.google.common.graph.ValueGraph
+
+@Suppress("UnstableApiUsage")
+fun <N : Any> Graph<N>.toImmutableGraph(): ImmutableGraph<N> = ImmutableGraph.copyOf(this)
+
+/**
+ * Maps the nodes of the [Graph].
+ *
+ * @param transform A mapping function applied to the nodes.
+ * @return A graph with mapped nodes.
+ */
+@Suppress("UnstableApiUsage")
+fun <N : Any, R : Any> Graph<out N>.mapNodes(
+    transform: (N) -> R
+): Graph<R> = mapGraphNodes(transform)
+
+/**
+ * Maps the nodes of the [ValueGraph].
+ *
+ * @param transform A mapping function applied to the nodes.
+ * @return A graph with mapped nodes.
+ */
+@Suppress("UnstableApiUsage")
+fun <N : Any, R : Any> ImmutableGraph<out N>.mapNodes(
+    transform: (N) -> R
+): ImmutableGraph<R> = mapGraphNodes(transform).toImmutableGraph()
+
+@Suppress("UnstableApiUsage", "MapGetWithNotNullAssertionOperator")
+private fun <N : Any, R : Any> Graph<N>.mapGraphNodes(
+    transform: (N) -> R
+): MutableGraph<R> {
+    val nodes = nodes()
+    val edges = edges()
+    val builder = if (isDirected) GraphBuilder.directed() else GraphBuilder.undirected()
+    val mutableGraph = builder.expectedNodeCount(nodes.size)
+        .allowsSelfLoops(allowsSelfLoops())
+        .build<R>()
+
+    val nodesRemapped = nodes.map { it to transform(it) }.toMap()
+    nodesRemapped.values.forEach { mutableGraph.addNode(it) }
+
+    edges.forEach {
+        // We just put these elements in the `nodesRemapped` above. They MUST be in the map.
+        val newNodeU = nodesRemapped[it.nodeU()]!!
+        val newNodeV = nodesRemapped[it.nodeV()]!!
+        mutableGraph.putEdge(newNodeU, newNodeV)
+    }
+
+    return mutableGraph
+}

--- a/core/src/test/kotlin/org/octogonapus/ktguava/collections/ImmutableGraphUtilTest.kt
+++ b/core/src/test/kotlin/org/octogonapus/ktguava/collections/ImmutableGraphUtilTest.kt
@@ -1,0 +1,85 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.octogonapus.ktguava.collections
+
+import com.google.common.graph.Graph
+import com.google.common.graph.GraphBuilder
+import com.google.common.graph.MutableGraph
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import kotlin.test.assertEquals
+
+internal class ImmutableGraphUtilTest {
+
+    @Test
+    fun `test toImmutableGraph`() {
+        val graph = makeMockGraph()
+        val immutableGraph = graph.toImmutableGraph()
+        assertGraphsAreEqual(graph, immutableGraph)
+    }
+
+    @Test
+    fun `test mapNodes with mutable receiver`() {
+        val graphMapped = makeMockGraph(listOf(0, 1)).mapNodes { it + 1 }
+        val expected = makeMockGraph(listOf(1, 2))
+        assertGraphsAreEqual(expected, graphMapped)
+    }
+
+    @Test
+    fun `test mapNodes with immutable receiver`() {
+        val graphMapped = makeMockGraph(listOf(0, 1))
+            .toImmutableGraph()
+            .mapNodes { it + 1 }
+        val expected = makeMockGraph(listOf(1, 2))
+        assertGraphsAreEqual(expected, graphMapped)
+    }
+
+    @Suppress("UnstableApiUsage")
+    @Test
+    fun `obeys self loops false`() {
+        val expected = GraphBuilder.directed().allowsSelfLoops(false).build<Int>()
+        val actual = expected.mapNodes { 0 }
+        assertEquals(expected.allowsSelfLoops(), actual.allowsSelfLoops())
+    }
+
+    @Suppress("UnstableApiUsage")
+    @Test
+    fun `obeys self loops true`() {
+        val expected = GraphBuilder.directed().allowsSelfLoops(true).build<Int>()
+        val actual = expected.mapNodes { 0 }
+        assertEquals(expected.allowsSelfLoops(), actual.allowsSelfLoops())
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun makeMockGraph(
+        nodeValues: List<Int> = listOf(0, 1)
+    ): MutableGraph<Int> =
+        GraphBuilder.undirected().build<Int>().apply {
+            nodeValues.forEach { addNode(it) }
+            nodeValues.chunked(2)
+                .map { it[0] to it[1] }
+                .forEach { (nodeU, nodeV) ->
+                    putEdge(nodeU, nodeV)
+                }
+        }
+
+    @Suppress("UnstableApiUsage")
+    private fun <N : Any> assertGraphsAreEqual(
+        expected: Graph<N>,
+        actual: Graph<N>
+    ) {
+        assertAll(
+            { assertEquals(expected.nodes(), actual.nodes()) },
+            { assertEquals(expected.edges(), actual.edges()) },
+            {
+                assertEquals(
+                    expected.nodes().flatMap { expected.incidentEdges(it) }.toSet(),
+                    actual.nodes().flatMap { actual.incidentEdges(it) }.toSet()
+                )
+            }
+        )
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR adds ImmutableGraphUtil.

### Motivation

These utilities have been missing for immutable graphs.

### Verification Process

Unit tests for the new features.

### Applicable Issues

Closes #4.
